### PR TITLE
Handle rate limits and missing constraint types

### DIFF
--- a/Home Connect Cloud/form.json
+++ b/Home Connect Cloud/form.json
@@ -1,6 +1,12 @@
 {
     "elements": [
         {
+            "type": "Label",
+            "name": "RateLimitNotice",
+            "caption": "",
+            "visible": false
+        },
+        {
             "type": "Button",
             "caption": "Register",
             "onClick": "echo HC_Register($id);"

--- a/Home Connect Cloud/locale.json
+++ b/Home Connect Cloud/locale.json
@@ -16,6 +16,7 @@
             "1000 calls in 1 day": "1000 Anfragen pro Tag",
             "50 calls in 1 minute": "50 Anfragen pro Minute",
             "A rate limit was reached. Requests are blocked until %s.": "Ein Anfragenlimit wurde erreicht. Weitere Anfragen werden bis %s blockiert",
+            "Home Connect requests are currently rate limited.": "Home-Connect-Anfragen sind aktuell limitiert.",
             "https://www.symcon.de/en/service/documentation/module-reference/home-connect/": "https://www.symcon.de/de/service/dokumentation/modulreferenz/home-connect"
         }
     }

--- a/Home Connect Cloud/module.php
+++ b/Home Connect Cloud/module.php
@@ -32,6 +32,7 @@ class HomeConnectCloud extends WebOAuthModule
         $this->RegisterAttributeString('Token', '');
 
         $this->RegisterAttributeString('RateError', '');
+        $this->RegisterAttributeInteger('RateLimitUntil', 0);
 
         $this->RequireParent('{2FADB4B7-FDAB-3C64-3E2C-068A4809849A}');
 
@@ -200,6 +201,7 @@ class HomeConnectCloud extends WebOAuthModule
     public function ResetRateLimit()
     {
         $this->WriteAttributeString('RateError', '');
+        $this->WriteAttributeInteger('RateLimitUntil', 0);
         $this->updateRateLimitNotice();
         $this->SetStatus(IS_ACTIVE);
         $this->SetTimerInterval('RateLimit', 0);
@@ -483,22 +485,9 @@ class HomeConnectCloud extends WebOAuthModule
         return $result;
     }
 
-    private function getTimer($name)
-    {
-        foreach (IPS_GetTimerList() as $timerID) {
-            $timer = IPS_GetTimer($timerID);
-            if (($timer['InstanceID'] == $this->InstanceID) && ($timer['Name'] == $name)) {
-                return $timer;
-                break;
-            }
-        }
-        return false;
-    }
-
     private function isRateLimitActive(): bool
     {
-        $timer = $this->getTimer('RateLimit');
-        return is_array($timer) && isset($timer['NextRun']) && $timer['NextRun'] > time();
+        return $this->ReadAttributeInteger('RateLimitUntil') > time();
     }
 
     private function updateRateLimitNotice(): void
@@ -552,10 +541,9 @@ class HomeConnectCloud extends WebOAuthModule
                     }
                 }
                 $retryAfter = $this->getRateLimitDelay($responseHeader, $response);
+                $nextRun = time() + $retryAfter;
+                $this->WriteAttributeInteger('RateLimitUntil', $nextRun);
                 $this->SetTimerInterval('RateLimit', $retryAfter * 1000);
-                $timer = $this->getTimer('RateLimit');
-                //Fallback to current time
-                $nextRun = $timer === false ? (time() + $retryAfter) : $timer['NextRun'];
 
                 $this->WriteAttributeString(
                     'RateError',

--- a/Home Connect Cloud/module.php
+++ b/Home Connect Cloud/module.php
@@ -203,7 +203,9 @@ class HomeConnectCloud extends WebOAuthModule
         $this->WriteAttributeString('RateError', '');
         $this->WriteAttributeInteger('RateLimitUntil', 0);
         $this->updateRateLimitNotice();
-        $this->SetStatus(IS_ACTIVE);
+        if ($this->GetStatus() != IS_ACTIVE) {
+            $this->SetStatus(IS_ACTIVE);
+        }
         $this->SetTimerInterval('RateLimit', 0);
     }
 

--- a/Home Connect Cloud/module.php
+++ b/Home Connect Cloud/module.php
@@ -497,62 +497,49 @@ class HomeConnectCloud extends WebOAuthModule
         $this->UpdateFormField('RateLimitNotice', 'visible', $rateError !== '');
     }
 
-    private function getRateLimitDelay(array $responseHeader, string $response): int
+    private function parseResponseHeaders(array $responseHeader): array
     {
         $head = [];
         foreach ($responseHeader as $header) {
             $values = explode(':', $header, 2);
             if (isset($values[1])) {
-                $head[trim($values[0])] = trim($values[1]);
+                $head[strtolower(trim($values[0]))] = trim($values[1]);
             }
         }
 
-        if (isset($head['Retry-After']) && is_numeric($head['Retry-After'])) {
-            return max(1, (int) $head['Retry-After']);
-        }
+        return $head;
+    }
 
-        $payload = json_decode($response, true);
-        $description = '';
-        if (is_array($payload) && isset($payload['error']['description'])) {
-            $description = (string) $payload['error']['description'];
-        }
+    private function getRateLimitDelay(array $responseHeader): int
+    {
+        $head = $this->parseResponseHeaders($responseHeader);
 
-        if ($description !== '' && preg_match('/remaining period of (\d+) seconds/i', $description, $matches)) {
-            return max(1, (int) $matches[1]);
-        }
-
-        if ($description !== '' && preg_match('/remaining period of (\d+) minutes?/i', $description, $matches)) {
-            return max(1, (int) $matches[1] * 60);
+        if (isset($head['retry-after']) && is_numeric($head['retry-after'])) {
+            return max(1, (int) $head['retry-after']);
         }
 
         return 60;
     }
 
-    private function handleHttpErrors($code, $responseHeader, string $response = '')
+    private function handleHttpErrors($code, $responseHeader)
     {
         switch ($code) {
             //Too Many Requests
             case 429:
-                $head = [];
-                foreach ($responseHeader as $header) {
-                    $values = explode(':', $header, 2);
-                    if (isset($values[1])) {
-                        $head[trim($values[0])] = trim($values[1]);
-                    }
-                }
-                $retryAfter = $this->getRateLimitDelay($responseHeader, $response);
+                $head = $this->parseResponseHeaders($responseHeader);
+                $retryAfter = $this->getRateLimitDelay($responseHeader);
                 $nextRun = time() + $retryAfter;
                 $this->WriteAttributeInteger('RateLimitUntil', $nextRun);
                 $this->SetTimerInterval('RateLimit', $retryAfter * 1000);
 
                 $this->WriteAttributeString(
                     'RateError',
-                    isset($head['Rate-Limit-Type']) ?
+                    isset($head['rate-limit-type']) ?
                     sprintf(
                         $this->Translate(
                             'The rate limit of %s was reached. Requests are blocked until %s.'
                         ),
-                        $head['Rate-Limit-Type'] == 'day' ?
+                        $head['rate-limit-type'] == 'day' ?
                         $this->Translate('1000 calls in 1 day') : $this->Translate('50 calls in 1 minute'),
                         date('d.m.Y H:i:s', $nextRun),
                     ) : sprintf($this->Translate('A rate limit was reached. Requests are blocked until %s.'), date('d.m.Y H:i:s', $nextRun))
@@ -587,7 +574,7 @@ class HomeConnectCloud extends WebOAuthModule
         if ($code == 200) {
             $this->ResetRateLimit();
         } else {
-            $this->handleHttpErrors($code, $http_response_header, is_string($result) ? $result : '');
+            $this->handleHttpErrors($code, $http_response_header);
         }
         return $result;
     }
@@ -617,7 +604,7 @@ class HomeConnectCloud extends WebOAuthModule
         if ($code == 204) {
             $this->ResetRateLimit();
         } else {
-            $this->handleHttpErrors($code, $http_response_header, is_string($result) ? $result : '');
+            $this->handleHttpErrors($code, $http_response_header);
         }
 
         if ((strpos($http_response_header[0], '201') === false)) {
@@ -650,7 +637,7 @@ class HomeConnectCloud extends WebOAuthModule
         if ($code == 204) {
             $this->ResetRateLimit();
         } else {
-            $this->handleHttpErrors($code, $http_response_header, is_string($result) ? $result : '');
+            $this->handleHttpErrors($code, $http_response_header);
         }
 
         return $result;

--- a/Home Connect Cloud/module.php
+++ b/Home Connect Cloud/module.php
@@ -71,6 +71,16 @@ class HomeConnectCloud extends WebOAuthModule
     {
         $data = json_decode($Data, true);
         $this->SendDebug('Forward', $Data, 0);
+        if ($this->isRateLimitActive()) {
+            $error = [
+                'error' => [
+                    'key'         => '429',
+                    'description' => $this->ReadAttributeString('RateError') ?: $this->Translate('Home Connect requests are currently rate limited.')
+                ]
+            ];
+            $this->SendDebug('ForwardRateLimit', json_encode($error), 0);
+            return json_encode($error);
+        }
         try {
             if (isset($data['Payload'])) {
                 $this->SendDebug('Payload', $data['Payload'], 0);
@@ -189,9 +199,8 @@ class HomeConnectCloud extends WebOAuthModule
 
     public function ResetRateLimit()
     {
-        if ($this->GetStatus() != IS_ACTIVE) {
-            $this->WriteAttributeString('RateError', '');
-        }
+        $this->WriteAttributeString('RateError', '');
+        $this->updateRateLimitNotice();
         $this->SetStatus(IS_ACTIVE);
         $this->SetTimerInterval('RateLimit', 0);
     }
@@ -199,11 +208,15 @@ class HomeConnectCloud extends WebOAuthModule
     public function GetConfigurationForm()
     {
         $form = json_decode(file_get_contents(__DIR__ . '/form.json'), true);
-        $form['status'][] = [
-            'code'    => IS_EBASE,
-            'icon'    => 'error',
-            'caption' => $this->ReadAttributeString('RateError'),
-        ];
+        $rateError = $this->ReadAttributeString('RateError');
+        foreach ($form['elements'] as &$element) {
+            if (($element['name'] ?? '') !== 'RateLimitNotice') {
+                continue;
+            }
+            $element['caption'] = $rateError;
+            $element['visible'] = $rateError !== '';
+            break;
+        }
 
         return json_encode($form);
     }
@@ -482,7 +495,51 @@ class HomeConnectCloud extends WebOAuthModule
         return false;
     }
 
-    private function handleHttpErrors($code, $responseHeader)
+    private function isRateLimitActive(): bool
+    {
+        $timer = $this->getTimer('RateLimit');
+        return is_array($timer) && isset($timer['NextRun']) && $timer['NextRun'] > time();
+    }
+
+    private function updateRateLimitNotice(): void
+    {
+        $rateError = $this->ReadAttributeString('RateError');
+        $this->UpdateFormField('RateLimitNotice', 'caption', $rateError);
+        $this->UpdateFormField('RateLimitNotice', 'visible', $rateError !== '');
+    }
+
+    private function getRateLimitDelay(array $responseHeader, string $response): int
+    {
+        $head = [];
+        foreach ($responseHeader as $header) {
+            $values = explode(':', $header, 2);
+            if (isset($values[1])) {
+                $head[trim($values[0])] = trim($values[1]);
+            }
+        }
+
+        if (isset($head['Retry-After']) && is_numeric($head['Retry-After'])) {
+            return max(1, (int) $head['Retry-After']);
+        }
+
+        $payload = json_decode($response, true);
+        $description = '';
+        if (is_array($payload) && isset($payload['error']['description'])) {
+            $description = (string) $payload['error']['description'];
+        }
+
+        if ($description !== '' && preg_match('/remaining period of (\d+) seconds/i', $description, $matches)) {
+            return max(1, (int) $matches[1]);
+        }
+
+        if ($description !== '' && preg_match('/remaining period of (\d+) minutes?/i', $description, $matches)) {
+            return max(1, (int) $matches[1] * 60);
+        }
+
+        return 60;
+    }
+
+    private function handleHttpErrors($code, $responseHeader, string $response = '')
     {
         switch ($code) {
             //Too Many Requests
@@ -494,10 +551,11 @@ class HomeConnectCloud extends WebOAuthModule
                         $head[trim($values[0])] = trim($values[1]);
                     }
                 }
-                $this->SetTimerInterval('RateLimit', $head['Retry-After'] * 1000);
+                $retryAfter = $this->getRateLimitDelay($responseHeader, $response);
+                $this->SetTimerInterval('RateLimit', $retryAfter * 1000);
                 $timer = $this->getTimer('RateLimit');
                 //Fallback to current time
-                $nextRun = $timer === false ? time() : $timer['NextRun'];
+                $nextRun = $timer === false ? (time() + $retryAfter) : $timer['NextRun'];
 
                 $this->WriteAttributeString(
                     'RateError',
@@ -511,9 +569,9 @@ class HomeConnectCloud extends WebOAuthModule
                         date('d.m.Y H:i:s', $nextRun),
                     ) : sprintf($this->Translate('A rate limit was reached. Requests are blocked until %s.'), date('d.m.Y H:i:s', $nextRun))
                 );
-                if ($this->GetStatus() != IS_EBASE) {
-                    $this->SetStatus(IS_EBASE);
-                    IPS_ApplyChanges($this->InstanceID);
+                $this->updateRateLimitNotice();
+                if ($this->HasActiveParent() && $this->GetStatus() != IS_ACTIVE) {
+                    $this->SetStatus(IS_ACTIVE);
                 }
                 return;
 
@@ -541,7 +599,7 @@ class HomeConnectCloud extends WebOAuthModule
         if ($code == 200) {
             $this->ResetRateLimit();
         } else {
-            $this->handleHttpErrors($code, $http_response_header);
+            $this->handleHttpErrors($code, $http_response_header, is_string($result) ? $result : '');
         }
         return $result;
     }
@@ -571,7 +629,7 @@ class HomeConnectCloud extends WebOAuthModule
         if ($code == 204) {
             $this->ResetRateLimit();
         } else {
-            $this->handleHttpErrors($code, $http_response_header);
+            $this->handleHttpErrors($code, $http_response_header, is_string($result) ? $result : '');
         }
 
         if ((strpos($http_response_header[0], '201') === false)) {
@@ -604,7 +662,7 @@ class HomeConnectCloud extends WebOAuthModule
         if ($code == 204) {
             $this->ResetRateLimit();
         } else {
-            $this->handleHttpErrors($code, $http_response_header);
+            $this->handleHttpErrors($code, $http_response_header, is_string($result) ? $result : '');
         }
 
         return $result;

--- a/Home Connect Device/module.php
+++ b/Home Connect Device/module.php
@@ -68,6 +68,7 @@ class HomeConnectDevice extends IPSModule
 
         $this->RegisterAttributeString('Settings', '[]');
         $this->RegisterAttributeString('OptionKeys', '[]');
+        $this->RegisterAttributeString('InitializationSignature', '');
 
         //Common States
         //States
@@ -129,7 +130,7 @@ class HomeConnectDevice extends IPSModule
         parent::ApplyChanges();
 
         if (IPS_GetKernelRunlevel() === KR_READY) {
-            $this->refreshDeviceState(true);
+            $this->refreshDeviceState($this->needsInitialization());
         }
 
         $this->SetReceiveDataFilter('.*' . $this->ReadPropertyString('HaID') . '.*');
@@ -142,7 +143,7 @@ class HomeConnectDevice extends IPSModule
 
         $parentID = IPS_GetInstance($this->InstanceID)['ConnectionID'];
         if ($SenderID == $parentID && $MessageID == IM_CHANGESTATUS) {
-            $this->refreshDeviceState($Data[0] == IS_ACTIVE);
+            $this->refreshDeviceState($Data[0] == IS_ACTIVE && $this->needsInitialization());
             return;
         }
 
@@ -150,7 +151,7 @@ class HomeConnectDevice extends IPSModule
             switch ($MessageID) {
                 case FM_CONNECT:
                     $this->RegisterMessage($Data[0], IM_CHANGESTATUS);
-                    $this->refreshDeviceState(true);
+                    $this->refreshDeviceState($this->needsInitialization());
                     return;
 
                 case FM_DISCONNECT:
@@ -384,6 +385,7 @@ class HomeConnectDevice extends IPSModule
             $this->createEventProfile();
             $this->MaintainVariable('Event', $this->Translate('Event'), VARIABLETYPE_STRING, 'HomeConnect.Event.' . $this->ReadPropertyString('DeviceType'), 0, true);
             $this->MaintainVariable('EventDescription', $this->Translate('Event Description'), VARIABLETYPE_STRING, '', 0, true);
+            $this->WriteAttributeString('InitializationSignature', $this->getInitializationSignature());
         }
     }
 
@@ -450,6 +452,27 @@ class HomeConnectDevice extends IPSModule
         }
 
         $this->SetStatus(IS_INACTIVE);
+    }
+
+    private function needsInitialization(): bool
+    {
+        if ($this->ReadPropertyString('HaID') == '') {
+            return false;
+        }
+
+        if (!@IPS_GetObjectIDByIdent('OperationState', $this->InstanceID)) {
+            return true;
+        }
+
+        return $this->ReadAttributeString('InitializationSignature') !== $this->getInitializationSignature();
+    }
+
+    private function getInitializationSignature(): string
+    {
+        return json_encode([
+            'HaID'       => $this->ReadPropertyString('HaID'),
+            'DeviceType' => $this->ReadPropertyString('DeviceType')
+        ]);
     }
 
     private function createPrograms()

--- a/Home Connect Device/module.php
+++ b/Home Connect Device/module.php
@@ -129,6 +129,8 @@ class HomeConnectDevice extends IPSModule
         //Never delete this line!
         parent::ApplyChanges();
 
+        $this->backfillInitializationSignature();
+
         if (IPS_GetKernelRunlevel() === KR_READY) {
             $this->refreshDeviceState($this->needsInitialization());
         }
@@ -465,6 +467,23 @@ class HomeConnectDevice extends IPSModule
         }
 
         return $this->ReadAttributeString('InitializationSignature') !== $this->getInitializationSignature();
+    }
+
+    private function backfillInitializationSignature(): void
+    {
+        if ($this->ReadPropertyString('HaID') == '') {
+            return;
+        }
+
+        if ($this->ReadAttributeString('InitializationSignature') !== '') {
+            return;
+        }
+
+        if (!@IPS_GetObjectIDByIdent('OperationState', $this->InstanceID)) {
+            return;
+        }
+
+        $this->WriteAttributeString('InitializationSignature', $this->getInitializationSignature());
     }
 
     private function getInitializationSignature(): string
@@ -964,22 +983,11 @@ class HomeConnectDevice extends IPSModule
             $ident = $attribute . $ident;
         }
 
-        switch ($data['type']) {
-            case 'Int':
-                $variableType = VARIABLETYPE_INTEGER;
-                break;
-
-            case 'Double':
-                $variableType = VARIABLETYPE_FLOAT;
-                break;
-
-            case 'Boolean':
-                $variableType = VARIABLETYPE_BOOLEAN;
-                break;
-
-            default:
-                $variableType = VARIABLETYPE_STRING;
-                break;
+        if (isset($data['type'])) {
+            $variableType = $this->mapConstraintTypeToVariableType($data['type']);
+        } else {
+            $variableType = $this->inferConstraintVariableType($data);
+            $this->SendDebug(__FUNCTION__, sprintf('Missing type for %s, inferred variable type: %d', $data['key'], $variableType), 0);
         }
         switch ($variableType) {
             case VARIABLETYPE_INTEGER:
@@ -1050,6 +1058,54 @@ class HomeConnectDevice extends IPSModule
                 $this->EnableAction($ident);
             }
         }
+    }
+
+    private function mapConstraintTypeToVariableType($type)
+    {
+        switch ($type) {
+            case 'Int':
+                return VARIABLETYPE_INTEGER;
+
+            case 'Double':
+                return VARIABLETYPE_FLOAT;
+
+            case 'Boolean':
+                return VARIABLETYPE_BOOLEAN;
+
+            default:
+                return VARIABLETYPE_STRING;
+        }
+    }
+
+    private function inferConstraintVariableType($data)
+    {
+        if (array_key_exists('value', $data)) {
+            return $this->getVariableType($data['value']);
+        }
+
+        $constraints = isset($data['constraints']) && is_array($data['constraints']) ? $data['constraints'] : [];
+
+        if (array_key_exists('default', $constraints)) {
+            return $this->getVariableType($constraints['default']);
+        }
+
+        if (isset($constraints['allowedvalues']) && is_array($constraints['allowedvalues']) && count($constraints['allowedvalues']) > 0) {
+            return $this->getVariableType($constraints['allowedvalues'][0]);
+        }
+
+        foreach (['min', 'max', 'stepsize'] as $numericConstraint) {
+            if (!isset($constraints[$numericConstraint]) || !is_numeric($constraints[$numericConstraint])) {
+                continue;
+            }
+
+            if ((float) $constraints[$numericConstraint] != (int) $constraints[$numericConstraint]) {
+                return VARIABLETYPE_FLOAT;
+            }
+
+            return VARIABLETYPE_INTEGER;
+        }
+
+        return VARIABLETYPE_STRING;
     }
 
     private function switchable()

--- a/library.json
+++ b/library.json
@@ -7,6 +7,6 @@
         "version": "6.0"
     },
     "version": "1.1",
-    "build": 9,
-    "date": 1779364800
+    "build": 10,
+    "date": 1779624000
 }

--- a/library.json
+++ b/library.json
@@ -7,6 +7,6 @@
         "version": "6.0"
     },
     "version": "1.1",
-    "build": 8,
-    "date": 1778241600
+    "build": 9,
+    "date": 1779364800
 }

--- a/tests/HomeConnectOvenTest.php
+++ b/tests/HomeConnectOvenTest.php
@@ -81,6 +81,26 @@ class HomeConnectOvenTest extends TestCase
         $this->assertEquals(IS_ACTIVE, IPS_GetInstance($oven)['InstanceStatus']);
     }
 
+    public function testBackfillsInitializationSignatureForExistingDeviceState()
+    {
+        $oven = IPS_CreateInstance('{F29DF312-A62E-9989-1F1A-0D1E1D171AD3}');
+        $operationState = IPS_CreateVariable(VARIABLETYPE_STRING);
+        IPS_SetParent($operationState, $oven);
+        IPS_SetIdent($operationState, 'OperationState');
+        IPS_SetName($operationState, 'Operation State');
+
+        IPS_SetProperty($oven, 'HaID', 'SIEMENS-HB676G5S6-68A40E2F702D');
+        IPS_SetProperty($oven, 'DeviceType', 'Oven');
+        IPS_ApplyChanges($oven);
+
+        $intf = IPS\InstanceManager::getInstanceInterface($oven);
+        $this->assertCount(1, IPS_GetChildrenIDs($oven));
+        $this->assertSame(
+            $this->invokeInstanceMethod($intf, 'getInitializationSignature'),
+            $this->invokeInstanceMethod($intf, 'ReadAttributeString', 'InitializationSignature')
+        );
+    }
+
     public function testStringSettingWithoutAllowedValuesDoesNotCrash()
     {
         $oven = IPS_CreateInstance('{F29DF312-A62E-9989-1F1A-0D1E1D171AD3}');
@@ -107,6 +127,34 @@ class HomeConnectOvenTest extends TestCase
         $this->assertNotFalse($variableID);
         $this->assertEquals(VARIABLETYPE_STRING, IPS_GetVariable($variableID)['VariableType']);
         $this->assertCount(0, IPS_GetVariableProfile('HomeConnect.Test.StringSetting')['Associations']);
+    }
+
+    public function testSettingWithoutTypeFallsBackToValueType()
+    {
+        $oven = IPS_CreateInstance('{F29DF312-A62E-9989-1F1A-0D1E1D171AD3}');
+        $intf = IPS\InstanceManager::getInstanceInterface($oven);
+
+        $method = new ReflectionMethod($intf, 'createVariableFromConstraints');
+        $method->setAccessible(true);
+        $method->invoke(
+            $intf,
+            'HomeConnect.Test.BooleanSetting',
+            [
+                'key'         => 'BSH.Common.Setting.ChildLock',
+                'name'        => 'Child Lock',
+                'value'       => false,
+                'constraints' => [
+                    'access' => 'readWrite'
+                ]
+            ],
+            'Setting',
+            1
+        );
+
+        $variableID = IPS_GetObjectIDByIdent('ChildLock', $oven);
+        $this->assertNotFalse($variableID);
+        $this->assertEquals(VARIABLETYPE_BOOLEAN, IPS_GetVariable($variableID)['VariableType']);
+        $this->assertEquals('HomeConnect.YesNo', IPS_GetVariable($variableID)['VariableProfile']);
     }
 
     private function generateTestData($tempValue)
@@ -173,5 +221,12 @@ class HomeConnectOvenTest extends TestCase
             }
         }
         return $result;
+    }
+
+    private function invokeInstanceMethod(object $instance, string $methodName, ...$arguments)
+    {
+        $method = new ReflectionMethod($instance, $methodName);
+        $method->setAccessible(true);
+        return $method->invoke($instance, ...$arguments);
     }
 }


### PR DESCRIPTION
## Summary
- handle Home Connect rate limit responses and avoid unnecessary reinitialization
- tolerate missing constraint types when creating setting and option variables
- bump library.json build metadata to 10

## Testing
- php phpunit.phar -c tests/phpunit.xml tests