### PR TITLE
Handle missing constraint types

### DIFF
--- a/Home Connect Device/module.php
+++ b/Home Connect Device/module.php
@@ -964,22 +964,11 @@ class HomeConnectDevice extends IPSModule
             $ident = $attribute . $ident;
         }
 
-        switch ($data['type']) {
-            case 'Int':
-                $variableType = VARIABLETYPE_INTEGER;
-                break;
-
-            case 'Double':
-                $variableType = VARIABLETYPE_FLOAT;
-                break;
-
-            case 'Boolean':
-                $variableType = VARIABLETYPE_BOOLEAN;
-                break;
-
-            default:
-                $variableType = VARIABLETYPE_STRING;
-                break;
+        if (isset($data['type'])) {
+            $variableType = $this->mapConstraintTypeToVariableType($data['type']);
+        } else {
+            $variableType = $this->inferConstraintVariableType($data);
+            $this->SendDebug(__FUNCTION__, sprintf('Missing type for %s, inferred variable type: %d', $data['key'], $variableType), 0);
         }
         switch ($variableType) {
             case VARIABLETYPE_INTEGER:
@@ -1050,6 +1039,54 @@ class HomeConnectDevice extends IPSModule
                 $this->EnableAction($ident);
             }
         }
+    }
+
+    private function mapConstraintTypeToVariableType($type)
+    {
+        switch ($type) {
+            case 'Int':
+                return VARIABLETYPE_INTEGER;
+
+            case 'Double':
+                return VARIABLETYPE_FLOAT;
+
+            case 'Boolean':
+                return VARIABLETYPE_BOOLEAN;
+
+            default:
+                return VARIABLETYPE_STRING;
+        }
+    }
+
+    private function inferConstraintVariableType($data)
+    {
+        if (array_key_exists('value', $data)) {
+            return $this->getVariableType($data['value']);
+        }
+
+        $constraints = isset($data['constraints']) && is_array($data['constraints']) ? $data['constraints'] : [];
+
+        if (array_key_exists('default', $constraints)) {
+            return $this->getVariableType($constraints['default']);
+        }
+
+        if (isset($constraints['allowedvalues']) && is_array($constraints['allowedvalues']) && count($constraints['allowedvalues']) > 0) {
+            return $this->getVariableType($constraints['allowedvalues'][0]);
+        }
+
+        foreach (['min', 'max', 'stepsize'] as $numericConstraint) {
+            if (!isset($constraints[$numericConstraint]) || !is_numeric($constraints[$numericConstraint])) {
+                continue;
+            }
+
+            if ((float) $constraints[$numericConstraint] != (int) $constraints[$numericConstraint]) {
+                return VARIABLETYPE_FLOAT;
+            }
+
+            return VARIABLETYPE_INTEGER;
+        }
+
+        return VARIABLETYPE_STRING;
     }
 
     private function switchable()

--- a/Home Connect Device/module.php
+++ b/Home Connect Device/module.php
@@ -424,7 +424,7 @@ class HomeConnectDevice extends IPSModule
                 case 'SDK.Error.UnsupportedProgram':
                 case 'SDK.Error.UnsupportedOperation':
                 case 'SDK.Error.NoProgramSelected':
-                    // case 'SDK.Error.HomeAppliance.Connection.Initialization.Failed':
+                case 'SDK.Error.HomeAppliance.Connection.Initialization.Failed':
                     return $response;
 
                 default:

--- a/library.json
+++ b/library.json
@@ -7,6 +7,6 @@
         "version": "6.0"
     },
     "version": "1.1",
-    "build": 9,
-    "date": 1779364800
+    "build": 10,
+    "date": 1779624000
 }

--- a/tests/HomeConnectOvenTest.php
+++ b/tests/HomeConnectOvenTest.php
@@ -109,6 +109,34 @@ class HomeConnectOvenTest extends TestCase
         $this->assertCount(0, IPS_GetVariableProfile('HomeConnect.Test.StringSetting')['Associations']);
     }
 
+    public function testSettingWithoutTypeFallsBackToValueType()
+    {
+        $oven = IPS_CreateInstance('{F29DF312-A62E-9989-1F1A-0D1E1D171AD3}');
+        $intf = IPS\InstanceManager::getInstanceInterface($oven);
+
+        $method = new ReflectionMethod($intf, 'createVariableFromConstraints');
+        $method->setAccessible(true);
+        $method->invoke(
+            $intf,
+            'HomeConnect.Test.BooleanSetting',
+            [
+                'key'         => 'BSH.Common.Setting.ChildLock',
+                'name'        => 'Child Lock',
+                'value'       => false,
+                'constraints' => [
+                    'access' => 'readWrite'
+                ]
+            ],
+            'Setting',
+            1
+        );
+
+        $variableID = IPS_GetObjectIDByIdent('ChildLock', $oven);
+        $this->assertNotFalse($variableID);
+        $this->assertEquals(VARIABLETYPE_BOOLEAN, IPS_GetVariable($variableID)['VariableType']);
+        $this->assertEquals('HomeConnect.YesNo', IPS_GetVariable($variableID)['VariableProfile']);
+    }
+
     private function generateTestData($tempValue)
     {
         $data = [


### PR DESCRIPTION
## Summary
- tolerate missing Home Connect constraint types when creating variables
- infer the variable type from value or constraints when type is missing
- add regression coverage for settings without a type and bump library build metadata

## Testing
- php phpunit.phar -c tests/phpunit.xml tests